### PR TITLE
Remove `jq` dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1-buster
 RUN apt update \
-  && apt install jq cmake -y \
+  && apt install cmake -y \
   && cargo install cargo-msrv --version "~0.15"
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The implementation of https://github.com/foresterre/cargo-msrv/issues/370 allows this docker action
to provide the MSRV without relying on jq to parse any JSON.

## To do

- [ ] Update `cargo-msrv` when available

******

Blocked by https://github.com/foresterre/cargo-msrv/milestone/3
